### PR TITLE
Update build process to use @vscode/vsce for packaging

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,9 +23,8 @@ jobs:
           npm install
 
       - name: Build
-        uses: lannonbr/vsce-action@4.0.0
-        with:
-          args: package
+        run: |
+          npx @vscode/vsce package
 
       - name: Set artifact name
         run: echo "ARTIFACT_NAME=$(echo quicktypofix-*.vsix)" >> $GITHUB_ENV

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ You can install this extension in two ways:
 4. Build the extension:
 
     ```sh
-    npx vsce package
+    npx @vscode/vsce package
     ```
 
 5. Install the extension with `install from VSIX...` in VS Code in the same way as the [above](#download-vsix-file).


### PR DESCRIPTION
Switch the build process to utilize `@vscode/vsce` for packaging the extension, ensuring consistency with the latest tools. Update documentation to reflect this change.